### PR TITLE
[bugfix] fix GuessMime from stream

### DIFF
--- a/src/Mime/Magic.cs
+++ b/src/Mime/Magic.cs
@@ -84,7 +84,9 @@ namespace HeyRed.Mime
         {
             ThrowIfDisposed();
 
-            var str = Marshal.PtrToStringAnsi(MagicNative.magic_buffer(_magic, buffer, bufferSize));
+            var length = buffer.Length < bufferSize ? buffer.Length : bufferSize;
+
+            var str = Marshal.PtrToStringAnsi(MagicNative.magic_buffer(_magic, buffer, length));
             if (str == null)
             {
                 throw new MagicException(LastError);

--- a/test/MimeTests/GuessExtension.cs
+++ b/test/MimeTests/GuessExtension.cs
@@ -12,7 +12,7 @@ namespace MimeTests
         public void GuessExtensionFromFilePath()
         {
             var expected = "jpeg";
-            string actual = MimeGuesser.GuessExtension(ResourceUtils.GetFileFixture);
+            string actual = MimeGuesser.GuessExtension(ResourceUtils.GetJpegFileFixture);
 
             Assert.Equal(expected, actual);
         }
@@ -20,7 +20,7 @@ namespace MimeTests
         [Fact]
         public void GuessExtensionFromBuffer()
         {
-            byte[] buffer = File.ReadAllBytes(ResourceUtils.GetFileFixture);
+            byte[] buffer = File.ReadAllBytes(ResourceUtils.GetJpegFileFixture);
             var expected = "jpeg";
             string actual = MimeGuesser.GuessExtension(buffer);
 
@@ -30,7 +30,7 @@ namespace MimeTests
         [Fact]
         public void GuessExtensionFromStream()
         {
-            using var stream = File.OpenRead(ResourceUtils.GetFileFixture);
+            using var stream = File.OpenRead(ResourceUtils.GetJpegFileFixture);
             string expected = "jpeg";
             string actual = MimeGuesser.GuessExtension(stream);
 
@@ -41,7 +41,7 @@ namespace MimeTests
         public void GuessExtensionFromFileInfo()
         {
             var expected = "jpeg";
-            var fi = new FileInfo(ResourceUtils.GetFileFixture);
+            var fi = new FileInfo(ResourceUtils.GetJpegFileFixture);
             string actual = fi.GuessExtension();
 
             Assert.Equal(expected, actual);

--- a/test/MimeTests/GuessFileType.cs
+++ b/test/MimeTests/GuessFileType.cs
@@ -12,7 +12,7 @@ namespace MimeTests
         public void GuessFileTypeFromFilePath()
         {
             var expected = new FileType("image/jpeg", "jpeg");
-            FileType actual = MimeGuesser.GuessFileType(ResourceUtils.GetFileFixture);
+            FileType actual = MimeGuesser.GuessFileType(ResourceUtils.GetJpegFileFixture);
 
             Assert.Equal(expected, actual);
         }
@@ -20,7 +20,7 @@ namespace MimeTests
         [Fact]
         public void GuessFileTypeFromBuffer()
         {
-            byte[] buffer = File.ReadAllBytes(ResourceUtils.GetFileFixture);
+            byte[] buffer = File.ReadAllBytes(ResourceUtils.GetJpegFileFixture);
             var expected = new FileType("image/jpeg", "jpeg");
             FileType actual = MimeGuesser.GuessFileType(buffer);
 
@@ -30,7 +30,7 @@ namespace MimeTests
         [Fact]
         public void GuessFileTypeFromStream()
         {
-            using var stream = File.OpenRead(ResourceUtils.GetFileFixture);
+            using var stream = File.OpenRead(ResourceUtils.GetJpegFileFixture);
             var expected = new FileType("image/jpeg", "jpeg");
             FileType actual = MimeGuesser.GuessFileType(stream);
 
@@ -41,7 +41,7 @@ namespace MimeTests
         public void GuessFileTypeFromFileInfo()
         {
             var expected = new FileType("image/jpeg", "jpeg");
-            var fi = new FileInfo(ResourceUtils.GetFileFixture);
+            var fi = new FileInfo(ResourceUtils.GetJpegFileFixture);
             FileType actual = fi.GuessFileType();
 
             Assert.Equal(expected, actual);

--- a/test/MimeTests/GuessMime.cs
+++ b/test/MimeTests/GuessMime.cs
@@ -12,7 +12,7 @@ namespace MimeTests
         public void GuessMimeFromFilePath()
         {
             var expected = "image/jpeg";
-            string actual = MimeGuesser.GuessMimeType(ResourceUtils.GetFileFixture);
+            string actual = MimeGuesser.GuessMimeType(ResourceUtils.GetJpegFileFixture);
 
             Assert.Equal(expected, actual);
         }
@@ -20,7 +20,7 @@ namespace MimeTests
         [Fact]
         public void GuessMimeFromBuffer()
         {
-            byte[] buffer = File.ReadAllBytes(ResourceUtils.GetFileFixture);
+            byte[] buffer = File.ReadAllBytes(ResourceUtils.GetJpegFileFixture);
             var expected = "image/jpeg";
             string actual = MimeGuesser.GuessMimeType(buffer);
 
@@ -30,8 +30,18 @@ namespace MimeTests
         [Fact]
         public void GuessMimeFromStream()
         {
-            using var stream = File.OpenRead(ResourceUtils.GetFileFixture);
+            using var stream = File.OpenRead(ResourceUtils.GetJpegFileFixture);
             var expected = "image/jpeg";
+            string actual = MimeGuesser.GuessMimeType(stream);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GuessMimeFromSmallTextStream()
+        {
+            using var stream = File.OpenRead(ResourceUtils.GetTextFileFixture);
+            var expected = "text/plain";
             string actual = MimeGuesser.GuessMimeType(stream);
 
             Assert.Equal(expected, actual);
@@ -41,7 +51,7 @@ namespace MimeTests
         public void GuessMimeFromFileInfo()
         {
             var expected = "image/jpeg";
-            var fi = new FileInfo(ResourceUtils.GetFileFixture);
+            var fi = new FileInfo(ResourceUtils.GetJpegFileFixture);
             string actual = fi.GuessMimeType();
 
             Assert.Equal(expected, actual);

--- a/test/MimeTests/ResourceUtils.cs
+++ b/test/MimeTests/ResourceUtils.cs
@@ -5,7 +5,10 @@ namespace MimeTests
 {
     public static class ResourceUtils
     {
-        public static string GetFileFixture =>
+        public static string GetJpegFileFixture =>
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestData", "test.jpeg");
+
+        public static string GetTextFileFixture =>
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestData", ".editorconfig");
     }
 }

--- a/test/MimeTests/TestData/.editorconfig
+++ b/test/MimeTests/TestData/.editorconfig
@@ -1,0 +1,8 @@
+is_global = true
+build_property.TargetFramework = net5.0
+build_property.TargetPlatformMinVersion = 
+build_property.UsingMicrosoftNETSdkWeb = 
+build_property.ProjectTypeGuids = 
+build_property.PublishSingleFile = 
+build_property.IncludeAllContentForSelfExtract = 
+build_property._SupportedPlatformList = Android,iOS,Linux,macOS,Windows


### PR DESCRIPTION
Fix MimeGuesser bug with files smaller than internal buffer (1024 bytes) while guessing with stream.

This library supports guessing mime type from a stream.
Internally the stream is converted to a byte array and limitted to the fisrt 1024 bytes.
As the whole buffer is used in the call of `libmagic.magic_buffer` there rubbish in the buffer for streams of files < 1024 bytes.
So the guessed mime type will be `octet/stream`, at least for small text files.

This is fixed and a test with a small text file is included.


### Remarks
As in some rare cases the mimetype guessing needs more than the leading 1024 bytes of a file, it is better to use the buffer- instead of the stream-function, as the former takes exactly the buffer you pass and does not cut at 1024 bytes.
